### PR TITLE
UHM-6440: Remove Check-In and Vital Signs app from home page

### DIFF
--- a/configuration/pih/pih-config-liberia-harper-dev.json
+++ b/configuration/pih/pih-config-liberia-harper-dev.json
@@ -13,6 +13,7 @@
     "dataExports",
     "checkInHomepageApp",
     "vitals",
+    "vitalsHomepageApp",
     "allergies",
     "markPatientDead",
     "relationships",

--- a/configuration/pih/pih-config-liberia-harper.json
+++ b/configuration/pih/pih-config-liberia-harper.json
@@ -18,6 +18,7 @@
     "dataExports",
     "checkInHomepageApp",
     "vitals",
+    "vitalsHomepageApp",
     "allergies",
     "markPatientDead",
     "relationships",

--- a/configuration/pih/pih-config-liberia-pleebo.json
+++ b/configuration/pih/pih-config-liberia-pleebo.json
@@ -18,6 +18,7 @@
     "dataExports",
     "checkInHomepageApp",
     "vitals",
+    "vitalsHomepageApp",
     "allergies",
     "markPatientDead",
     "relationships",


### PR DESCRIPTION
@tommyiversonj  we recently made a chance to the PIH EMR components so that the VItals Home Page app could be turned off, while keep the Vitals form on... to do this, we moved the Vitals Home Page app into a different component. This PR just makes sure that the Vitals Home Page app stays on for the Liberia servers... fyi @lnball