### PR TITLE
Add ignoreStatusCodes to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,3 +41,4 @@ jobs:
         customHeaders: '{"Accept": "application/json"}'
         retry: 60
         retryWait: 60000
+        ignoreStatusCodes: 400


### PR DESCRIPTION
Prevent build hang when bamboo job is disabled.